### PR TITLE
Revert test suite and fix unit tests

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -5,3 +5,6 @@
 package.xml
 **.profile-meta.xml
 **.settings-meta.xml
+
+#ignore files which can't be packaged
+**/force_di_teststuite.testSuite-meta.xml

--- a/force-di/test/classes/di_InjectorTest.cls
+++ b/force-di/test/classes/di_InjectorTest.cls
@@ -170,7 +170,7 @@ private class di_InjectorTest {
             new di_BindingConfigWrapper(
                 'testQualifiedApiName',
                 di_InjectorTest.InterfaceForTest.class.getName(), 
-                'testNamespacePrefix', 
+                null, 
                 'Apex',
                 di_InjectorTest.ClassForTest.class.getName(),
                 'Account',
@@ -196,7 +196,7 @@ private class di_InjectorTest {
             new di_BindingConfigWrapper(
                 'testQualifiedApiName',
                 di_InjectorTest.InterfaceForTest.class.getName(), 
-                'testNamespacePrefix', 
+                null, 
                 'Apex',
                 di_InjectorTest.ClassForTest.class.getName(),
                 null,

--- a/force-di/test/testSuites/force_di_teststuite.testSuite-meta.xml
+++ b/force-di/test/testSuites/force_di_teststuite.testSuite-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">
+    <testClassName>di_BindingConfigWrapperTest</testClassName>
+    <testClassName>di_BindingParamTest</testClassName>
+    <testClassName>di_BindingTest</testClassName>
+    <testClassName>di_FlowTest</testClassName>
+    <testClassName>di_InjectorCMPFlowProxyControllerTest</testClassName>
+    <testClassName>di_InjectorComponentControllerTest</testClassName>
+    <testClassName>di_InjectorControllerTest</testClassName>
+    <testClassName>di_InjectorTest</testClassName>
+    <testClassName>di_ModuleTest</testClassName>
+    <testClassName>di_PlatformCacheTest</testClassName>
+</ApexTestSuite>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
       "default": true
     }
   ],
-  "namespace": "fHCM2",
+  "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
   "sourceApiVersion": "60.0"
 }


### PR DESCRIPTION
The test class has been reintroduced to keep the force-di framework as closely aligned to the origin as possible. This file is not ignored in deployments to orgs rather than omitted from the repository.

Unit test fixtures that referenced a non-existent namespace have been changed to remove the namespace now that the code takes namespaces into account.